### PR TITLE
Update for CF Diego compatibility

### DIFF
--- a/wagtail/README.md
+++ b/wagtail/README.md
@@ -22,7 +22,7 @@ We will create a user by pushing a local sqlite file with a created account.
 
 #### Add a Procfile to the root of your project
 ```
-web: python manage.py migrate && python manage.py runserver $VCAP_APP_HOST:$PORT
+web: python manage.py migrate && python manage.py runserver $HOST:$PORT
 ```
 
 _Note: This will create a new superuser every deploy for now_

--- a/wagtail/README.md
+++ b/wagtail/README.md
@@ -22,7 +22,7 @@ We will create a user by pushing a local sqlite file with a created account.
 
 #### Add a Procfile to the root of your project
 ```
-web: python manage.py migrate && python manage.py runserver $HOST:$PORT
+web: python manage.py migrate && python manage.py runserver 0.0.0.0:$PORT
 ```
 
 _Note: This will create a new superuser every deploy for now_


### PR DESCRIPTION
Per [Cloud Foundry documentation] use of `$VCAP_APP_HOST` and `$VCAP_APP_PASSWORD` are incompatible with newer (Diego-based) Cloud Foundry deployments. This change makes this repository forward compatible with the new cloud.gov environment deployment in AWS GovCloud.
